### PR TITLE
Typo/From & to Vaults typo

### DIFF
--- a/components/ModalVaultList.js
+++ b/components/ModalVaultList.js
@@ -13,7 +13,7 @@ import	{Transition}							from	'@headlessui/react';
 import	useAccount								from	'contexts/useAccount';
 import	{toAddress}								from	'utils';
 
-function ModalVaultList({vaults, value, set_value, disabled}) {
+function ModalVaultList({vaults, label, value, set_value, disabled}) {
 	const	{balancesOf} = useAccount();
 	const	[open, set_open] = useState(false);
 	const	[filter, set_filter] = useState('');
@@ -82,7 +82,7 @@ function ModalVaultList({vaults, value, set_value, disabled}) {
 										<path fillRule={'evenodd'} clipRule={'evenodd'} d={'M14.8144 17.7439C14.5417 18.0556 14.0678 18.0872 13.7561 17.8144L7.75612 12.5644C7.59336 12.422 7.5 12.2163 7.5 12C7.5 11.7837 7.59336 11.578 7.75612 11.4356L13.7561 6.18558C14.0678 5.91282 14.5417 5.9444 14.8144 6.25613C15.0872 6.56786 15.0556 7.04168 14.7439 7.31444L9.38894 12L14.7439 16.6856C15.0556 16.9583 15.0872 17.4321 14.8144 17.7439Z'} fill={'white'}/>
 									</svg>
 									<h3 as={'h3'} className={'text-lg font-medium text-white'}>
-										{'Select from vault'}
+										{label}
 									</h3>
 									<div />
 								</div>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -41,7 +41,7 @@ function	Navbar({hasSecret}) {
 			<p
 				onClick={() => {deactivate(); onDesactivate();}}
 				suppressHydrationWarning
-				className={'ml-8 inline-flex px-6 py-3 items-center leading-4 rounded-lg text-sm cursor-pointer whitespace-nowrap bg-white text-gray-800 border border-solid border-white hover:bg-white hover:text-gray-900 transition-colors'}>
+				className={'ml-8 inline-flex px-6 py-3 items-center leading-4 rounded-lg text-sm cursor-pointer whitespace-nowrap bg-white text-gray-800 border border-solid border-gray-100 hover:bg-white hover:text-gray-900 transition-colors shadow-sm'}>
 				<svg className={'mr-2'} width={'16'} height={'16'} viewBox={'0 0 16 16'} fill={'none'} xmlns={'http://www.w3.org/2000/svg'}>
 					<path d={'M12.6667 0H3.33333C1.46667 0 0 1.46667 0 3.33333V12.6667C0 14.5333 1.46667 16 3.33333 16H12.6667C14.5333 16 16 14.5333 16 12.6667V3.33333C16 1.46667 14.5333 0 12.6667 0ZM4.66667 5C5.2 5 5.66667 5.46667 5.66667 6C5.66667 6.53333 5.2 7 4.66667 7C4.13333 7 3.66667 6.53333 3.66667 6C3.66667 5.46667 4.13333 5 4.66667 5ZM12.0667 10.4C10.9333 11.4667 9.46667 12.0667 8 12.0667C6.53333 12.0667 5 11.4667 3.93333 10.4C3.8 10.2667 3.73333 10.1333 3.73333 9.93333C3.73333 9.53333 4 9.26667 4.4 9.26667C4.6 9.26667 4.73333 9.33333 4.86667 9.46667C5.73333 10.3333 6.86667 10.8 8 10.8C9.13333 10.8 10.2667 10.3333 11.1333 9.46667C11.2667 9.33333 11.4 9.26667 11.6 9.26667C12 9.26667 12.2667 9.53333 12.2667 9.93333C12.2667 10.1333 12.2 10.2667 12.0667 10.4ZM11.3333 7C10.8 7 10.3333 6.53333 10.3333 6C10.3333 5.46667 10.8 5 11.3333 5C11.8667 5 12.3333 5.46667 12.3333 6C12.3333 6.53333 11.8667 7 11.3333 7Z'} fill={stringToColour(ens || `${address.slice(0, 4)}...${address.slice(-4)}`)}/>
 				</svg>

--- a/pages/index.js
+++ b/pages/index.js
@@ -29,6 +29,7 @@ function	SectionFromVault({vaults, fromVault, set_fromVault, fromAmount, set_fro
 			<div className={'flex flex-col md:flex-row items-start justify-center space-y-2 md:space-y-0 md:space-x-4 w-full'}>
 				<div className={'w-full md:w-4/11'}>
 					<ModalVaultList
+						label={'Select from vault'}
 						disabled={disabled}
 						vaults={vaults}
 						value={fromVault}
@@ -57,6 +58,7 @@ function	SectionToVault({vaults, toVault, set_toVault, expectedReceiveAmount, to
 			<div className={'flex flex-col md:flex-row items-start justify-center space-y-2 md:space-y-0 md:space-x-4 w-full'}>
 				<div className={'w-full md:w-4/11'}>
 					<ModalVaultList
+						label={'Select to vault'}
 						disabled={disabled}
 						vaults={vaults}
 						value={toVault}


### PR DESCRIPTION
## What it does ✨
Fix a typo on the vaults selection modal where the title of the modal was always `Select from Vault`.
Adding a new argument `label` to customize it.

## How to test ✅
When opening the modal, the correct title should be displayed.