### PR TITLE
BugFix/Fixing slippage 

### DIFF
--- a/components/PopoverSlippage.js
+++ b/components/PopoverSlippage.js
@@ -61,7 +61,7 @@ function PopoverSlippage({slippage, set_slippage}) {
 										<input
 											id={'slippage'}
 											autoComplete={'off'}
-											value={Number(slippage).toString()}
+											value={slippage}
 											onChange={(e) => {
 												set_slippage(e.target.value);
 											}}

--- a/pages/index.js
+++ b/pages/index.js
@@ -192,7 +192,7 @@ function	Index({hasSecret}) {
 	const	[toCounterValue, set_toCounterValue] = useState(0);
 	const	[expectedReceiveAmount, set_expectedReceiveAmount] = useState('');
 
-	const	[slippage, set_slippage] = useState(0.01);
+	const	[slippage, set_slippage] = useState(0.05);
 	const	[isFetchingExpectedReceiveAmount, set_isFetchingExpectedReceiveAmount] = useState(false);
 
 	const	debouncedFetchExpectedAmount = useDebounce(fromAmount, 500);


### PR DESCRIPTION
## What it does ✨
- Increasing the default slippage from 0.01 to 0.05 to avoid instant revert
- Fixing the slippage input to be able to actually update `0.0X` values (bug when adding a 0 after the dot, the input would be reseted to 0).

## How to test ✅
When trying to perform a swap with the default slippage, the metamask popup should open.
You should be able to correctly change the slippage