### PR TITLE
BugFix/Crash when typing some characters in input field

### DIFF
--- a/components/InputToken.js
+++ b/components/InputToken.js
@@ -57,7 +57,7 @@ function	InputToken({value, set_value, slippage, set_slippage, balanceOf, decima
 						if (disabled) {
 							return;
 						}
-						let		_value = e.target.value.replaceAll('..', '.').replaceAll(/[a-zA-Z]/g, '');
+						let		_value = e.target.value.replaceAll('..', '.').replaceAll(/[^0-9.]/g, '');
 						const	[dec, frac] = _value.split('.');
 						if (frac) _value = `${dec}.${frac.slice(0, 10)}`;
 


### PR DESCRIPTION
## What it does ✨
The amount Input should only accept numeric characters and `.`. Non alpha-numeric characters were accepted, such as `]` which could lead to a crash of the dAPP.

## How to test ✅
On the input, you should be able to type only numeric characters and `.`.