### PR TITLE
Feature/Slippage too high message

### DIFF
--- a/components/Bowswap/index.js
+++ b/components/Bowswap/index.js
@@ -104,15 +104,23 @@ function	ButtonSwap({fromVault, toVault, fromAmount, expectedReceiveAmount, slip
 					instructions: V2_PATHS.find(path => path[0] === fromVault.address && path[1] === toVault.address)?.[2]
 				}, ({error}) => {
 					if (error) {
+						let message = undefined;
+						if (error?.data?.message?.includes('revert out too low')) {
+							message = 'SLIPPAGE TOO HIGH. TO PROCEED, PLEASE INCREASE THE SLIPPAGE TOLERANCE';
+						}
 						set_transactionProcessing(false);
-						return onCallback('error');
+						return onCallback('error', message);
 					}
 					set_transactionProcessing(false);
 					onCallback('success');
 				});
 			} catch (error) {
+				let message = undefined;
+				if (error?.data?.message?.includes('revert out too low')) {
+					message = 'SLIPPAGE TOO HIGH. TO PROCEED, PLEASE INCREASE THE SLIPPAGE TOLERANCE';
+				}
 				set_transactionProcessing(false);
-				return onCallback('error');
+				return onCallback('error', message);
 			}
 		} else {
 			try {
@@ -125,15 +133,23 @@ function	ButtonSwap({fromVault, toVault, fromAmount, expectedReceiveAmount, slip
 					minAmountOut: ethers.utils.parseUnits((expectedReceiveAmount - (expectedReceiveAmount * slippage / 100)).toString(), fromVault.decimals)
 				}, ({error}) => {
 					if (error) {
+						let message = undefined;
+						if (error?.data?.message?.includes('revert out too low')) {
+							message = 'SLIPPAGE TOO HIGH. TO PROCEED, PLEASE INCREASE THE SLIPPAGE TOLERANCE';
+						}
 						set_transactionProcessing(false);
-						return onCallback('error');
+						return onCallback('error', message);
 					}
 					set_transactionProcessing(false);
 					onCallback('success');
 				});
 			} catch (error) {
+				let message = undefined;
+				if (error?.data?.message?.includes('revert out too low')) {
+					message = 'SLIPPAGE TOO HIGH. TO PROCEED, PLEASE INCREASE THE SLIPPAGE TOLERANCE';
+				}
 				set_transactionProcessing(false);
-				return onCallback('error');
+				return onCallback('error', message);
 			}
 		}
 	}
@@ -416,6 +432,8 @@ function	Bowswap({yearnVaultData, prices}) {
 				return {open: true, title: 'APPROVE COMPLETED', color: 'bg-success', icon: <Success width={24} height={24} className={'mr-4'} />};
 			if (txSwapStatus.success)
 				return {open: true, title: 'SWAP COMPLETED', color: 'bg-success', icon: <Success width={24} height={24} className={'mr-4'} />};
+			if (txSwapStatus.error && txSwapStatus.message)
+				return {open: true, title: txSwapStatus.message, color: 'bg-error', icon: <Error width={28} height={24} className={'mr-4'} />};
 			if (txSwapStatus.error)
 				return {open: true, title: 'SWAP FAILED', color: 'bg-error', icon: <Error width={28} height={24} className={'mr-4'} />};
 			if (txApproveStatus.error)
@@ -498,10 +516,10 @@ function	Bowswap({yearnVaultData, prices}) {
 						fromAmount={fromAmount}
 						expectedReceiveAmount={expectedReceiveAmount}
 						slippage={slippage}
-						onCallback={(type) => {
-							set_txSwapStatus({none: false, pending: type === 'pending', error: type === 'error', success: type === 'success'});
+						onCallback={(type, message) => {
+							set_txSwapStatus({none: false, pending: type === 'pending', error: type === 'error', success: type === 'success', message});
 							if (type === 'error') {
-								setTimeout(() => set_txSwapStatus((s) => s.error ? {none: true, pending: false, error: false, success: false} : s), 2500);
+								setTimeout(() => set_txSwapStatus((s) => s.error ? {none: true, pending: false, error: false, success: false, message} : s), 2500);
 							}
 							if (type === 'success') {
 								updateBalanceOf([fromVault.address, toVault.address]);

--- a/utils/actions.js
+++ b/utils/actions.js
@@ -63,7 +63,7 @@ export async function	metapoolSwapTokens({provider, contractAddress, from, to, a
 			callback({error: true, data: undefined});
 		}
 	} catch (error) {
-		callback({error: true, data: undefined});
+		callback({error: error, data: undefined});
 	}
 }
 
@@ -88,7 +88,7 @@ export async function	swapTokens({provider, contractAddress, from, to, amount, m
 			callback({error: true, data: undefined});
 		}
 	} catch (error) {
-		callback({error: true, data: undefined});
+		callback({error: error, data: undefined});
 	}
 }
 
@@ -112,6 +112,6 @@ export async function	migrateBachTokens({provider, contractAddress, batch}, call
 		}
 	} catch (error) {
 		console.error(error);
-		callback({error: true, data: undefined});
+		callback({error: error, data: undefined});
 	}
 }


### PR DESCRIPTION
## What it does ✨
Sometime when the slippage was too important for the selected slippage tolerance, the transaction would fail without metamask to pop and without more reason.
To avoid this, add a specific message when the test tx revert with `amount too low`.

## How to test ✅
Set a very low slippage on a not slippage safe swap (triCrypto - 3pool for example) and test it

## BowNote 🏹
We should find a way to get insight about such errors to be able to fix them quickly